### PR TITLE
fix(visualize): show actionable error when Bun runtime is missing

### DIFF
--- a/cli/src/commands/visualize.ts
+++ b/cli/src/commands/visualize.ts
@@ -324,7 +324,30 @@ export async function visualizeCommand(
 
     // Handle process errors
     serverProcess.on("error", (error) => {
-      const message = `Failed to start visualization server: ${error.message}`
+      const errorCode = (error as NodeJS.ErrnoException).code
+      let message: string
+      let suggestions: string[] | undefined
+
+      if (errorCode === "ENOENT") {
+        // `dr visualize` currently spawns its server as a Bun subprocess (see #800 for
+        // the plan to remove this dependency). On a fresh `npm install -g` there's no
+        // reason Bun would be present, so this is an expected, actionable failure mode
+        // rather than an unexpected crash - explain it instead of surfacing the raw
+        // "spawn bun ENOENT".
+        message = "dr visualize requires the Bun runtime, which was not found on this system."
+        suggestions = [
+          "Install Bun: https://bun.sh/docs/installation",
+          "  curl -fsSL https://bun.sh/install | bash   (macOS/Linux)",
+          "  powershell -c \"irm bun.sh/install.ps1 | iex\"   (Windows)",
+          "After installing, make sure `bun` is on your PATH, then re-run `dr visualize`.",
+          "Tracking issue: https://github.com/tinkermonkey/documentation_robotics/issues/800",
+        ]
+      } else if (errorCode === "EACCES") {
+        message = "dr visualize could not run the Bun runtime: permission denied."
+        suggestions = ["Check that the `bun` executable on your PATH is executable (chmod +x)."]
+      } else {
+        message = `Failed to start visualization server: ${error.message}`
+      }
 
       // Record error in startup span if still active
       if (isTelemetryEnabled && serverStartupSpan) {
@@ -339,9 +362,10 @@ export async function visualizeCommand(
         })()
       }
 
-      // Print error before throwing (CLI wrapper expects CLIError messages to be pre-printed)
-      console.error(message)
-      const cliError = new CLIError(message, 1)
+      // Don't print here: rejecting propagates this CLIError up through the catch block
+      // below to the top-level CLI handler, which prints `.format()` (including
+      // `suggestions`) exactly once. Printing here too would duplicate the whole block.
+      const cliError = new CLIError(message, 1, suggestions)
       if (rejectKeepAlive) {
         rejectKeepAlive(cliError)
       }


### PR DESCRIPTION
## Summary

Fixes #799 — `dr visualize` crashed with a raw, unexplained `Failed to start visualization server: spawn bun ENOENT` when the Bun runtime isn't installed (true for every fresh `npm install -g @documentation-robotics/cli`, since `bun` is devDependency-only).

## What changed

`dr visualize` spawns its server as a Bun subprocess (`spawn("bun", [...])` in `cli/src/commands/visualize.ts`). The process `error` handler now inspects the spawn error code:

- **`ENOENT`** — explains that Bun is required, gives install instructions for macOS/Linux/Windows, and links #800 (tracking the real fix: removing the Bun dependency from the visualization server entirely).
- **`EACCES`** — points directly at the executable-permission issue.
- anything else — unchanged generic message.

```
Error: dr visualize requires the Bun runtime, which was not found on this system.

Suggestions:
  • Install Bun: https://bun.sh/docs/installation
  •   curl -fsSL https://bun.sh/install | bash   (macOS/Linux)
  •   powershell -c "irm bun.sh/install.ps1 | iex"   (Windows)
  • After installing, make sure `bun` is on your PATH, then re-run `dr visualize`.
  • Tracking issue: https://github.com/tinkermonkey/documentation_robotics/issues/800
```

## Bonus fix: duplicate error print

While implementing this I noticed the handler used to `console.error()` a plain message and *then* throw a `CLIError`, which `cli.ts`'s top-level handler also prints via `error.format()` — producing the exact same block twice. Removed the redundant inner print so the `CLIError` (now carrying a `suggestions` array, rendered as a proper bulleted "Suggestions:" section) is printed exactly once, at the top level.

## Verification

- Stripped `bun` from `PATH`, ran the built CLI against a real initialized model: prints the message once, with suggestions, exit code 1
- Confirmed the happy path (`bun` present) still starts/stops cleanly (`SIGINT` handling, server startup message, token URL)
- `npx tsc --noEmit` clean
- `npm run test:unit` — 276 + 177 tests pass, 0 fail

## Related

- #799 (fixed by this PR — the crash itself)
- #800 (not fixed here — tracks actually removing the Bun runtime dependency; this PR only makes the failure mode clear until that's done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
