### PR TITLE
fix(visualize): port dr visualize server off Bun-specific runtime APIs

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "@documentation-robotics/cli",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@documentation-robotics/cli",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@clack/prompts": "^0.8.0",
+        "@hono/node-server": "^1.19.17",
+        "@hono/node-ws": "^1.3.1",
         "@hono/swagger-ui": "^0.5.3",
         "@hono/zod-openapi": "^1.2.1",
         "@hono/zod-validator": "^0.7.6",
@@ -20,6 +22,7 @@
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.0",
         "ansis": "^3.0.0",
+        "chokidar": "^4.0.3",
         "commander": "^12.0.0",
         "glob": "^11.1.0",
         "graphology": "^0.25.4",
@@ -587,6 +590,34 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@hono/node-ws": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-ws/-/node-ws-1.3.1.tgz",
+      "integrity": "sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "@hono/node-server": "^1.19.11",
+        "hono": "^4.6.0"
       }
     },
     "node_modules/@hono/swagger-ui": {
@@ -1602,6 +1633,21 @@
         "@types/node": "*"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -2275,6 +2321,19 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/require-directory": {
@@ -3128,6 +3187,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -56,6 +56,8 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
     "@clack/prompts": "^0.8.0",
+    "@hono/node-server": "^1.19.17",
+    "@hono/node-ws": "^1.3.1",
     "@hono/swagger-ui": "^0.5.3",
     "@hono/zod-openapi": "^1.2.1",
     "@hono/zod-validator": "^0.7.6",
@@ -65,6 +67,7 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.0",
     "ansis": "^3.0.0",
+    "chokidar": "^4.0.3",
     "commander": "^12.0.0",
     "glob": "^11.1.0",
     "graphology": "^0.25.4",

--- a/cli/src/commands/visualize.ts
+++ b/cli/src/commands/visualize.ts
@@ -106,7 +106,7 @@ export async function visualizeCommand(
       logDebug("[Telemetry] TELEMETRY_ENABLED is false - no spans will be created")
     }
 
-    // Spawn server in Bun subprocess with environment variables
+    // Build environment variables for the server subprocess
     const env: Record<string, string> = {
       ...process.env,
       DR_VISUALIZE_PORT: String(port),
@@ -159,8 +159,9 @@ export async function visualizeCommand(
         const chunk = data.toString()
         serverOutput += chunk
 
-        // Process each line individually: Bun's pipe buffering often batches multiple
-        // console.log calls (e.g. "running at" + "TOKEN:") into a single data event.
+        // Process each line individually: stdio pipe buffering can batch multiple
+        // console.log calls (e.g. "running at" + "TOKEN:") into a single data event,
+        // regardless of runtime.
         // Using startsWith/substring on the whole chunk would either miss the TOKEN line
         // (when "running at" is first) or extract a malformed token (when trailing lines
         // are appended), causing the browser to open with the wrong token and get a 403.

--- a/cli/src/commands/visualize.ts
+++ b/cli/src/commands/visualize.ts
@@ -139,7 +139,11 @@ export async function visualizeCommand(
       logDebug(`Using custom viewer from: ${options.viewerPath}`)
     }
 
-    const serverProcess = spawn("bun", ["run", serverEntryPath], {
+    // Reuse whichever runtime is currently executing the CLI (node or bun) to launch
+    // the server subprocess. server-entry.ts has no Bun-specific dependencies (see #800),
+    // so this works identically under Node.js or Bun — and unlike spawning a literal
+    // "bun" binary, process.execPath is guaranteed to exist since it's already running.
+    const serverProcess = spawn(process.execPath, [serverEntryPath], {
       cwd: process.cwd(),
       stdio: ["pipe", "pipe", "pipe"],
       env,
@@ -328,23 +332,13 @@ export async function visualizeCommand(
       let message: string
       let suggestions: string[] | undefined
 
-      if (errorCode === "ENOENT") {
-        // `dr visualize` currently spawns its server as a Bun subprocess (see #800 for
-        // the plan to remove this dependency). On a fresh `npm install -g` there's no
-        // reason Bun would be present, so this is an expected, actionable failure mode
-        // rather than an unexpected crash - explain it instead of surfacing the raw
-        // "spawn bun ENOENT".
-        message = "dr visualize requires the Bun runtime, which was not found on this system."
-        suggestions = [
-          "Install Bun: https://bun.sh/docs/installation",
-          "  curl -fsSL https://bun.sh/install | bash   (macOS/Linux)",
-          "  powershell -c \"irm bun.sh/install.ps1 | iex\"   (Windows)",
-          "After installing, make sure `bun` is on your PATH, then re-run `dr visualize`.",
-          "Tracking issue: https://github.com/tinkermonkey/documentation_robotics/issues/800",
-        ]
-      } else if (errorCode === "EACCES") {
-        message = "dr visualize could not run the Bun runtime: permission denied."
-        suggestions = ["Check that the `bun` executable on your PATH is executable (chmod +x)."]
+      // The server subprocess is launched via process.execPath (the same node/bun
+      // binary already running this CLI), so it's always present - ENOENT here would
+      // indicate something unusual about the runtime environment rather than a missing
+      // dependency (see #800: this used to hard-depend on a separately installed `bun`).
+      if (errorCode === "EACCES") {
+        message = `dr visualize could not run the visualization server: permission denied executing ${process.execPath}.`
+        suggestions = [`Check that ${process.execPath} is executable (chmod +x).`]
       } else {
         message = `Failed to start visualization server: ${error.message}`
       }

--- a/cli/src/server-entry.ts
+++ b/cli/src/server-entry.ts
@@ -1,7 +1,8 @@
 /**
  * Visualization Server Entry Point
- * This is a Bun-specific entry point for running the visualization server
- * It receives configuration via environment variables and starts the server
+ * This is spawned as a subprocess by `dr visualize` (see cli/src/commands/visualize.ts),
+ * using whichever runtime (Node.js or Bun) is already running the parent CLI process.
+ * It receives configuration via environment variables and starts the server.
  */
 
 import { Model } from "./core/model.js";

--- a/cli/src/server/server.ts
+++ b/cli/src/server/server.ts
@@ -6,48 +6,15 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { cors } from "hono/cors";
 import { swaggerUI } from "@hono/swagger-ui";
+import { serve } from "@hono/node-server";
+import { createNodeWebSocket } from "@hono/node-ws";
+import { spawn, spawnSync, type ChildProcess } from "child_process";
+import chokidar from "chokidar";
 import { randomBytes } from "crypto";
 import { createRequire } from "module";
 import { fileURLToPath } from "url";
 import path from "path";
 
-// hono/bun imports are conditional - they're only available in Bun runtime
-// For Node.js/tsx environments (e.g., generating OpenAPI spec), these are lazily imported
-// These are conditionally loaded in loadBunAdapters() and remain undefined in non-Bun runtimes
-// Bun-specific WebSocket upgrade middleware from hono/bun
-// Only available in Bun runtime; undefined in Node.js/tsx
-let upgradeWebSocket: any;
-// Bun-specific WebSocket middleware from hono/bun
-// Only available in Bun runtime; undefined in Node.js/tsx
-let websocket: any;
-
-/**
- * NOTE: Module-scoped WebSocket adapter state
- *
- * upgradeWebSocket and websocket are declared as module-level let variables and mutated
- * in the constructor via loadBunAdapters(). This creates intentional coupling between
- * VisualizationServer instances: they all share the same adapter references.
- *
- * DESIGN RATIONALE:
- * - These adapters are loaded from the Bun runtime at module-load time and are immutable
- *   after initialization. The Bun runtime itself is global state.
- * - In practice, all VisualizationServer instances will call loadBunAdapters() with the same
- *   inputs and will get the same results (or the same errors).
- * - Creating separate instance-level copies would add unnecessary memory overhead without
- *   providing benefits, since the adapters cannot be meaningfully different per instance.
- * - The coupling is acceptable because:
- *   1. These are runtime environment adapters, not request-specific state
- *   2. They are immutable after initialization (set once in first constructor call)
- *   3. Tests and production code all use a single VisualizationServer instance per process
- *
- * ALTERNATIVE APPROACHES (rejected):
- * - Instance properties: Would duplicate adapter references unnecessarily
- * - Lazy initialization in methods: Would cause per-request overhead
- * - Singleton pattern: Would require additional infrastructure without clear benefits
- *
- * If future requirements demand multiple independent VisualizationServer instances
- * with different WebSocket configurations, this design can be revisited.
- */
 const require = createRequire(import.meta.url);
 import { Model } from "../core/model.js";
 import { Element } from "../core/element.js";
@@ -132,8 +99,9 @@ type AnnotationReply = z.infer<typeof AnnotationReplySchema>;
 // Derive ClientAnnotation type from AnnotationSchema with proper serialization
 type ClientAnnotation = z.infer<typeof AnnotationSchema>;
 
-// Type for WebSocket context from Hono/Bun
-// Defines the interface for WebSocket operations within the Hono/Bun environment
+// Type for WebSocket context from Hono's WebSocket helper (hono/ws), shared by all
+// runtime adapters (@hono/node-ws, hono/bun, hono/cloudflare-workers, etc.)
+// Defines the interface for WebSocket operations within the Hono environment
 interface HonoWSContext {
   send(source: string | ArrayBuffer | Uint8Array | ArrayBufferView, options?: { compress?: boolean }): void;
   close(code?: number, reason?: string): void;
@@ -152,7 +120,9 @@ export interface VisualizationServerOptions {
 export class VisualizationServer {
   private app: OpenAPIHono;
   private model: Model;
-  private _server?: any; // Bun.serve return type, loaded dynamically
+  private _server?: ReturnType<typeof serve>; // Node HTTP server returned by @hono/node-server
+  private upgradeWebSocket?: ReturnType<typeof createNodeWebSocket>["upgradeWebSocket"];
+  private injectWebSocket?: ReturnType<typeof createNodeWebSocket>["injectWebSocket"];
   private clients: Set<HonoWSContext> = new Set();
   private watcher?: any;
   private annotations: Map<string, ClientAnnotation> = new Map(); // annotationId -> annotation
@@ -164,7 +134,7 @@ export class VisualizationServer {
   private authEnabled: boolean = true;
   private withDanger: boolean = false; // Danger mode disabled by default
   private viewerPath?: string; // Optional custom viewer path
-  private activeChatProcesses: Map<string, any> = new Map(); // conversationId -> Bun.spawn process
+  private activeChatProcesses: Map<string, ChildProcess> = new Map(); // conversationId -> spawned chat process
   private chatConversationCounter: number = 0;
   private selectedChatClient?: BaseChatClient; // Selected chat client for server
   private chatInitializationError?: Error; // Store initialization error for status endpoint
@@ -270,8 +240,10 @@ export class VisualizationServer {
     this.app = new OpenAPIHono();
     this.model = model;
 
-    // Load Bun-specific imports if available (for WebSocket support in Bun runtime)
-    this.loadBunAdapters();
+    // Set up the WebSocket adapter for this app instance (works under both
+    // Node.js and Bun, since @hono/node-server/@hono/node-ws use Node's
+    // http module, which Bun also implements).
+    this.loadWebSocketAdapter();
 
     // Auth configuration (CLI options override environment variables)
     this.authEnabled = options?.authEnabled ?? process.env.DR_AUTH_ENABLED !== "false";
@@ -340,30 +312,25 @@ export class VisualizationServer {
   }
 
   /**
-   * Load Bun-specific WebSocket adapters if available
-   * This is called in the constructor to support WebSocket functionality in Bun runtime
-   * In Node.js/tsx environments (e.g., generating OpenAPI spec), these imports are skipped
+   * Set up the WebSocket adapter for this server instance
+   * This is called in the constructor to support WebSocket functionality via @hono/node-ws,
+   * which works identically under Node.js and Bun (both implement Node's http module).
+   * Wrapped in try/catch so a WS setup failure degrades gracefully instead of crashing
+   * the whole server (e.g. non-server contexts like generating the OpenAPI spec).
    */
-  private loadBunAdapters(): void {
-    // Check if we're running in Bun runtime by checking for Bun global
-    if (typeof (global as any).Bun !== "undefined") {
-      try {
-        // Use dynamic import for Bun-specific adapters
-        // This is safe to call only in Bun runtime
-        const honoModule = require("hono/bun") as any;
-        upgradeWebSocket = honoModule.upgradeWebSocket;
-        websocket = honoModule.websocket;
-      } catch (error) {
-        // Log error details for production debugging (not just VERBOSE mode)
-        const message = error instanceof Error ? error.message : String(error);
-        console.warn(
-          `[Server] WARNING: Could not load WebSocket adapters from hono/bun: ${message}. ` +
-            `WebSocket endpoints (/ws) will not be available. ` +
-            `Please ensure 'hono' is installed and the Bun runtime is properly configured.`
-        );
-        if (process.env.VERBOSE && error instanceof Error && error.stack) {
-          console.debug("[Server] Stack trace:", error.stack);
-        }
+  private loadWebSocketAdapter(): void {
+    try {
+      const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app: this.app });
+      this.injectWebSocket = injectWebSocket;
+      this.upgradeWebSocket = upgradeWebSocket;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `[Server] WARNING: Could not set up WebSocket adapter: ${message}. ` +
+          `WebSocket endpoints (/ws) will not be available.`
+      );
+      if (process.env.VERBOSE && error instanceof Error && error.stack) {
+        console.debug("[Server] Stack trace:", error.stack);
       }
     }
   }
@@ -1309,8 +1276,8 @@ export class VisualizationServer {
     this.app.get('/api-docs', swaggerUI({ url: '/api-spec.yaml' }));
 
     // WebSocket endpoint
-    // Only register if WebSocket adapter is available (Bun runtime)
-    if (upgradeWebSocket) {
+    // Only register if the WebSocket adapter was set up successfully
+    if (this.upgradeWebSocket) {
       this.app.get(
         "/ws",
         async (c, next) => {
@@ -1372,7 +1339,7 @@ export class VisualizationServer {
 
           return next();
         },
-        upgradeWebSocket(() => ({
+        this.upgradeWebSocket(() => ({
         onOpen: async (_evt: any, ws: HonoWSContext) => {
           // Telemetry: Track WebSocket connection
           await this.recordWebSocketEvent("ws.connection.open", {
@@ -2097,23 +2064,19 @@ export class VisualizationServer {
       cmd.push("--verbose", "--output-format", "stream-json");
 
       // Launch claude with dr-architect agent for comprehensive DR expertise
-      const proc = Bun.spawn({
-        cmd,
+      const proc = spawn(cmd[0], cmd.slice(1), {
         cwd: this.model.rootPath,
-        stdin: "pipe",
-        stdout: "pipe",
-        stderr: "pipe",
+        stdio: ["pipe", "pipe", "pipe"],
       });
 
       // Store active process
       this.activeChatProcesses.set(conversationId, proc);
 
       // Send user message via stdin (like Python prototype)
-      proc.stdin?.write(new TextEncoder().encode(message));
+      proc.stdin?.write(message);
       proc.stdin?.end();
 
       // Stream stdout (JSON events)
-      const stdoutReader = proc.stdout.getReader();
       const decoder = new TextDecoder();
 
       const streamOutput = async () => {
@@ -2121,11 +2084,8 @@ export class VisualizationServer {
         let buffer = "";
 
         try {
-          while (true) {
-            const { done, value } = await stdoutReader.read();
-            if (done) break;
-
-            const chunk = decoder.decode(value, { stream: true });
+          for await (const chunkBuf of proc.stdout!) {
+            const chunk = decoder.decode(chunkBuf, { stream: true });
             buffer += chunk;
 
             // Process complete lines (JSON events)
@@ -2225,7 +2185,7 @@ export class VisualizationServer {
           }
 
           // Wait for process to complete
-          const exitCode = await proc.exited;
+          const exitCode = await this.waitForExit(proc);
 
           // Clean up
           this.activeChatProcesses.delete(conversationId);
@@ -2319,13 +2279,11 @@ export class VisualizationServer {
       let cmd: string[];
 
       // Check if gh CLI with copilot extension is available
-      const ghResult = Bun.spawnSync({
-        cmd: ["gh", "copilot", "--version"],
-        stdout: "pipe",
-        stderr: "pipe",
+      const ghResult = spawnSync("gh", ["copilot", "--version"], {
+        stdio: ["ignore", "pipe", "pipe"],
       });
 
-      if (ghResult.exitCode === 0) {
+      if (ghResult.status === 0) {
         cmd = ["gh", "copilot", "explain"];
 
         // Add allow-all-tools flag if withDanger is enabled
@@ -2347,30 +2305,23 @@ export class VisualizationServer {
       }
 
       // Launch GitHub Copilot
-      const proc = Bun.spawn({
-        cmd,
+      const proc = spawn(cmd[0], cmd.slice(1), {
         cwd: this.model.rootPath,
-        stdin: "pipe",
-        stdout: "pipe",
-        stderr: "pipe",
+        stdio: ["pipe", "pipe", "pipe"],
       });
 
       // Store active process
       this.activeChatProcesses.set(conversationId, proc);
 
       // GitHub Copilot outputs plain text/markdown (not JSON)
-      const stdoutReader = proc.stdout.getReader();
       const decoder = new TextDecoder();
 
       const streamOutput = async () => {
         let accumulatedText = "";
 
         try {
-          while (true) {
-            const { done, value } = await stdoutReader.read();
-            if (done) break;
-
-            const chunk = decoder.decode(value, { stream: true });
+          for await (const chunkBuf of proc.stdout!) {
+            const chunk = decoder.decode(chunkBuf, { stream: true });
             accumulatedText += chunk;
 
             // Send text chunk as it arrives
@@ -2389,7 +2340,7 @@ export class VisualizationServer {
           }
 
           // Wait for process to complete
-          const exitCode = await proc.exited;
+          const exitCode = await this.waitForExit(proc);
 
           // Clean up
           this.activeChatProcesses.delete(conversationId);
@@ -2458,47 +2409,49 @@ export class VisualizationServer {
   private setupFileWatcher(): void {
     const modelPath = `${this.model.rootPath}/documentation-robotics/model`;
 
-    // Use Bun's global watch API (cast to any due to type definitions)
-    const bunWatch = (globalThis as any).Bun?.watch;
-    if (!bunWatch) {
-      console.warn("[Watcher] Bun.watch not available, file watching disabled");
-      return;
-    }
-
+    // Use chokidar for cross-platform recursive watching. Node's built-in fs.watch
+    // only supports the `recursive` option on macOS and Windows (not Linux), which
+    // would silently drop file-change events on Linux dev/CI machines.
     try {
-      this.watcher = bunWatch(modelPath, {
-        recursive: true,
-        onChange: async (_event: string, path: string) => {
-          if (process.env.VERBOSE) {
-            console.log(`[Watcher] File changed: ${path}`);
-          }
+      this.watcher = chokidar.watch(modelPath, {
+        persistent: true,
+        ignoreInitial: true,
+      });
 
-          try {
-            // Reload model and changesets
-            this.model = await Model.load(this.model.rootPath, { lazyLoad: false });
-            await this.loadChangesetsFromDisk();
+      this.watcher.on("all", async (_event: string, path: string) => {
+        if (process.env.VERBOSE) {
+          console.log(`[Watcher] File changed: ${path}`);
+        }
 
-            // Broadcast update to all clients
-            const modelData = await this.serializeModel();
-            const message = JSON.stringify({
-              type: "model.updated",
-              data: modelData,
-              timestamp: new Date().toISOString(),
-            });
+        try {
+          // Reload model and changesets
+          this.model = await Model.load(this.model.rootPath, { lazyLoad: false });
+          await this.loadChangesetsFromDisk();
 
-            for (const client of this.clients) {
-              try {
-                client.send(message);
-              } catch (error) {
-                const msg = getErrorMessage(error);
-                console.warn(`[Watcher] Failed to send update: ${msg}`);
-              }
+          // Broadcast update to all clients
+          const modelData = await this.serializeModel();
+          const message = JSON.stringify({
+            type: "model.updated",
+            data: modelData,
+            timestamp: new Date().toISOString(),
+          });
+
+          for (const client of this.clients) {
+            try {
+              client.send(message);
+            } catch (error) {
+              const msg = getErrorMessage(error);
+              console.warn(`[Watcher] Failed to send update: ${msg}`);
             }
-          } catch (error) {
-            const message = getErrorMessage(error);
-            console.error(`[Watcher] Failed to reload model: ${message}`);
           }
-        },
+        } catch (error) {
+          const message = getErrorMessage(error);
+          console.error(`[Watcher] Failed to reload model: ${message}`);
+        }
+      });
+
+      this.watcher.on("error", (err: unknown) => {
+        console.warn(`[Watcher] Could not watch ${modelPath}: ${getErrorMessage(err)}`);
       });
     } catch (err) {
       console.warn(`[Watcher] Could not watch ${modelPath}: ${err}`);
@@ -3259,14 +3212,15 @@ export class VisualizationServer {
 
     this.setupFileWatcher();
 
-    // Dynamically import serve from bun to allow usage with non-Bun runtimes
-    const { serve } = await import("bun");
-
+    // @hono/node-server works identically under Node.js and Bun (both implement
+    // Node's http module), so no runtime-specific branching is needed here.
     this._server = serve({
       port,
       fetch: this.app.fetch,
-      websocket, // Add WebSocket handler from hono/bun
     });
+
+    // Wire up the WebSocket upgrade handler on the underlying HTTP server
+    this.injectWebSocket?.(this._server);
 
     console.log(`✓ Visualization server running at http://localhost:${port}`);
   }
@@ -3286,11 +3240,27 @@ export class VisualizationServer {
   }
 
   /**
+   * Wait for a spawned child process to exit and resolve with its exit code
+   * Node's ChildProcess doesn't expose a Bun-style `.exited` promise, so this
+   * wraps the "exit" event (or the already-set exitCode, if it fired before
+   * we started listening).
+   */
+  private waitForExit(proc: ChildProcess): Promise<number> {
+    return new Promise((resolve) => {
+      if (proc.exitCode !== null) {
+        resolve(proc.exitCode);
+        return;
+      }
+      proc.once("exit", (code) => resolve(code ?? 0));
+    });
+  }
+
+  /**
    * Kill a process with retry logic and exponential backoff
    * Attempts graceful SIGTERM first, then force SIGKILL if needed
    */
   private async killProcessWithRetry(
-    proc: any,
+    proc: ChildProcess,
     conversationId: string,
     label: string
   ): Promise<void> {
@@ -3366,7 +3336,11 @@ export class VisualizationServer {
 
     // Stop the server
     if (this._server) {
-      this._server.stop();
+      this._server.close((error) => {
+        if (error && process.env.VERBOSE) {
+          console.warn(`[SERVER] Error while closing HTTP server: ${getErrorMessage(error)}`);
+        }
+      });
     }
   }
 }

--- a/cli/src/server/server.ts
+++ b/cli/src/server/server.ts
@@ -2098,6 +2098,10 @@ export class VisualizationServer {
           );
         }
       });
+      // A failed spawn also destroys the stdio streams Node already created, which can
+      // raise a second, separate unhandled 'error' event on `proc.stdin` itself. Swallow
+      // it here since the handler above already reports the failure to the client.
+      proc.stdin?.on("error", () => {});
 
       // Store active process
       this.activeChatProcesses.set(conversationId, proc);
@@ -2235,6 +2239,15 @@ export class VisualizationServer {
             })
           );
         } catch (error) {
+          // A process that never actually spawned (see the proc.on("error", ...)
+          // handler above, which already reported this failure to the client) has no
+          // pid - Node assigns one synchronously only once posix_spawn succeeds. Bail
+          // out here instead of sending a second, duplicate JSON-RPC response for the
+          // same request or trying to kill a process that never started.
+          if (!proc.pid) {
+            return;
+          }
+
           const errorMsg = getErrorMessage(error);
 
           ws.send(
@@ -2380,6 +2393,9 @@ export class VisualizationServer {
           );
         }
       });
+      // See the matching guard in launchClaudeCodeChat: a failed spawn can also raise a
+      // separate unhandled 'error' event on the stdin stream Node already created.
+      proc.stdin?.on("error", () => {});
 
       // Store active process
       this.activeChatProcesses.set(conversationId, proc);
@@ -2431,6 +2447,13 @@ export class VisualizationServer {
             })
           );
         } catch (error) {
+          // See the matching guard in launchClaudeCodeChat: a process that never
+          // actually spawned has no pid, and its own proc.on("error", ...) handler
+          // above already reported the failure - avoid a duplicate response/kill.
+          if (!proc.pid) {
+            return;
+          }
+
           const errorMsg = getErrorMessage(error);
 
           ws.send(

--- a/cli/src/server/server.ts
+++ b/cli/src/server/server.ts
@@ -315,8 +315,9 @@ export class VisualizationServer {
    * Set up the WebSocket adapter for this server instance
    * This is called in the constructor to support WebSocket functionality via @hono/node-ws,
    * which works identically under Node.js and Bun (both implement Node's http module).
-   * Wrapped in try/catch so a WS setup failure degrades gracefully instead of crashing
-   * the whole server (e.g. non-server contexts like generating the OpenAPI spec).
+   * Wrapped in try/catch as a defensive guard so a WS setup failure would degrade the
+   * server gracefully (no /ws route) rather than crash construction entirely, in case
+   * this ever becomes fallible again in the future.
    */
   private loadWebSocketAdapter(): void {
     try {
@@ -1380,7 +1381,7 @@ export class VisualizationServer {
 
           try {
             // Extract the actual message data
-            // In Hono/Bun, message is a MessageEvent with a data property
+            // In Hono's WebSocket helper, message is a MessageEvent with a data property
             const rawData = (message as any).data ?? message;
 
             // Handle different message types (string, Buffer, ArrayBuffer)
@@ -2069,6 +2070,35 @@ export class VisualizationServer {
         stdio: ["pipe", "pipe", "pipe"],
       });
 
+      // Node reports spawn failures (e.g. ENOENT if `claude` isn't on PATH) asynchronously
+      // via an 'error' event rather than a synchronous throw. Without this handler, an
+      // unhandled 'error' event on the ChildProcess EventEmitter throws and crashes the
+      // whole server (server-entry.ts's uncaughtException handler tears the process down)
+      // instead of just failing this one chat request.
+      proc.on("error", (err) => {
+        const errorMsg = getErrorMessage(err);
+        console.error(
+          `[Claude Code] Failed to spawn subprocess for conversation ${conversationId}: ${errorMsg}`
+        );
+        this.activeChatProcesses.delete(conversationId);
+        try {
+          ws.send(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: JSONRPC_ERRORS.INTERNAL_ERROR,
+                message: `Failed to launch Claude Code: ${errorMsg}`,
+              },
+              id: requestId,
+            })
+          );
+        } catch (sendError) {
+          console.error(
+            `[Claude Code] Failed to send spawn-error notification: ${getErrorMessage(sendError)}`
+          );
+        }
+      });
+
       // Store active process
       this.activeChatProcesses.set(conversationId, proc);
 
@@ -2283,6 +2313,19 @@ export class VisualizationServer {
         stdio: ["ignore", "pipe", "pipe"],
       });
 
+      // Log why we're falling back to standalone copilot, for debuggability: `gh`
+      // missing (ENOENT), `gh` present but the copilot extension isn't installed
+      // (non-zero exit), or another spawn failure are otherwise indistinguishable.
+      if (ghResult.error) {
+        console.warn(
+          `[Copilot] 'gh copilot --version' probe failed to spawn: ${getErrorMessage(ghResult.error)}`
+        );
+      } else if (ghResult.status !== 0 && process.env.VERBOSE) {
+        console.log(
+          `[Copilot] 'gh copilot' unavailable (exit ${ghResult.status}), falling back to standalone 'copilot'`
+        );
+      }
+
       if (ghResult.status === 0) {
         cmd = ["gh", "copilot", "explain"];
 
@@ -2308,6 +2351,34 @@ export class VisualizationServer {
       const proc = spawn(cmd[0], cmd.slice(1), {
         cwd: this.model.rootPath,
         stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      // See the matching handler in launchClaudeCodeChat: Node reports spawn failures
+      // (e.g. ENOENT if `gh`/`copilot` isn't on PATH) asynchronously via an 'error'
+      // event, and an unhandled one would crash the whole server instead of just this
+      // one chat request.
+      proc.on("error", (err) => {
+        const errorMsg = getErrorMessage(err);
+        console.error(
+          `[Copilot] Failed to spawn subprocess for conversation ${conversationId}: ${errorMsg}`
+        );
+        this.activeChatProcesses.delete(conversationId);
+        try {
+          ws.send(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              error: {
+                code: JSONRPC_ERRORS.INTERNAL_ERROR,
+                message: `Failed to launch GitHub Copilot: ${errorMsg}`,
+              },
+              id: requestId,
+            })
+          );
+        } catch (sendError) {
+          console.error(
+            `[Copilot] Failed to send spawn-error notification: ${getErrorMessage(sendError)}`
+          );
+        }
       });
 
       // Store active process
@@ -2409,9 +2480,10 @@ export class VisualizationServer {
   private setupFileWatcher(): void {
     const modelPath = `${this.model.rootPath}/documentation-robotics/model`;
 
-    // Use chokidar for cross-platform recursive watching. Node's built-in fs.watch
-    // only supports the `recursive` option on macOS and Windows (not Linux), which
-    // would silently drop file-change events on Linux dev/CI machines.
+    // Use chokidar for consistent, well-tested cross-platform recursive watching
+    // rather than Node's built-in recursive fs.watch (Linux support for the
+    // `recursive` option only landed in Node 19.1.0, and its maturity/event
+    // semantics still vary more by platform than chokidar's).
     try {
       this.watcher = chokidar.watch(modelPath, {
         persistent: true,
@@ -3219,6 +3291,22 @@ export class VisualizationServer {
       fetch: this.app.fetch,
     });
 
+    // Node reports bind failures (e.g. EADDRINUSE from a still-running previous
+    // instance) asynchronously via an 'error' event rather than a synchronous throw.
+    // Waiting on it here turns that into a clean, catchable rejection instead of an
+    // unhandled 'error' event that would otherwise crash the whole process via
+    // server-entry.ts's uncaughtException handler.
+    await new Promise<void>((resolve, reject) => {
+      this._server!.once("listening", resolve);
+      this._server!.once("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "EADDRINUSE") {
+          reject(new Error(`Port ${port} is already in use. Try a different port with --port <port>.`));
+        } else {
+          reject(err);
+        }
+      });
+    });
+
     // Wire up the WebSocket upgrade handler on the underlying HTTP server
     this.injectWebSocket?.(this._server);
 
@@ -3256,6 +3344,20 @@ export class VisualizationServer {
   }
 
   /**
+   * Whether a child process has actually terminated.
+   *
+   * NOTE: Node's `ChildProcess.killed` means "kill() was successfully used to send a
+   * signal" — it does NOT mean the process has exited (a process can ignore SIGTERM
+   * and keep running with `.killed === true`). This differs from Bun's
+   * `Subprocess.killed`, which does mean "has the process exited". Use exitCode/
+   * signalCode (set only once the process has actually terminated) instead of
+   * `.killed` to decide whether retry/escalation is still needed.
+   */
+  private hasExited(proc: ChildProcess): boolean {
+    return proc.exitCode !== null || proc.signalCode !== null;
+  }
+
+  /**
    * Kill a process with retry logic and exponential backoff
    * Attempts graceful SIGTERM first, then force SIGKILL if needed
    */
@@ -3270,7 +3372,7 @@ export class VisualizationServer {
 
     while (attempt < maxRetries) {
       try {
-        if (proc.killed) {
+        if (this.hasExited(proc)) {
           // Process already terminated
           return;
         }
@@ -3281,7 +3383,7 @@ export class VisualizationServer {
         // Wait for process to exit gracefully
         await new Promise((resolve) => setTimeout(resolve, 500));
 
-        if (proc.killed) {
+        if (this.hasExited(proc)) {
           return;
         }
       } catch (error) {
@@ -3298,7 +3400,7 @@ export class VisualizationServer {
 
     // Force kill if graceful shutdown failed
     try {
-      if (!proc.killed) {
+      if (!this.hasExited(proc)) {
         proc.kill("SIGKILL");
         console.warn(
           `[${label}] Process for conversation ${conversationId} did not respond to SIGTERM, force killed with SIGKILL`

--- a/cli/tests/integration/visualization-server-comprehensive.test.ts
+++ b/cli/tests/integration/visualization-server-comprehensive.test.ts
@@ -664,6 +664,75 @@ describe.serial("Visualization Server - File Watching", () => {
     const reloadedLayer = await reloadedModel.getLayer("motivation");
     expect(reloadedLayer?.elements.size).toBe(initialCount + 1);
   });
+
+  // The test above only proves the file changed on disk - it reloads the model itself
+  // independently rather than checking anything about the server's own watcher/broadcast
+  // behavior, so it would pass identically even if the watcher (chokidar, since PR #803's
+  // Bun -> Node migration) were completely broken. This test instead asserts the server's
+  // actual watcher-driven side effect: that editing a model file causes a live WebSocket
+  // client to receive a "model.updated" broadcast with the updated data.
+  it("should broadcast model.updated over WebSocket when a watched file changes", async () => {
+    const ws = new WebSocket(`ws://localhost:${watchingPort}/ws`);
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("WebSocket never opened")), 10000);
+      ws.onopen = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      ws.onerror = (err) => {
+        clearTimeout(timer);
+        reject(err);
+      };
+    });
+
+    // The previous test in this describe.serial block also edits a model file and
+    // triggers the same watcher/broadcast; a stray "model.updated" from that edit can
+    // still be in flight when this test's WS connects. Only resolve on the broadcast
+    // that actually reflects *this* test's edit, not just the first one that arrives.
+    const updatePromise = new Promise<any>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error("Timed out waiting for model.updated broadcast containing motivation-goal-g4"));
+      }, 10000);
+      ws.onmessage = (event) => {
+        const message = JSON.parse(event.data as string);
+        // Match on `name` rather than `id`: the model layer may normalize/rewrite the
+        // id it was constructed with (e.g. to a UUID with a separate dot-notation
+        // `path`), so `name` is the more reliable identifier for what we just added.
+        if (
+          message.type === "model.updated" &&
+          message.data?.nodes?.some((n: any) => n.name === "Broadcast Test Goal")
+        ) {
+          clearTimeout(timer);
+          resolve(message);
+        }
+      };
+    });
+
+    const motivationLayer = await model.getLayer("motivation");
+    if (motivationLayer) {
+      motivationLayer.addElement(
+        new Element({
+          id: "motivation-goal-g4",
+          name: "Broadcast Test Goal",
+          type: "goal",
+          description: "Added to trigger a watcher broadcast",
+          attributes: {},
+          relationships: [],
+          references: [],
+          layer: "motivation",
+        })
+      );
+      await model.saveLayer("motivation");
+    }
+
+    const update = await updatePromise;
+    expect(update.type).toBe("model.updated");
+    expect(update.data).toBeDefined();
+    expect(Array.isArray(update.data.nodes)).toBe(true);
+    expect(update.data.nodes.some((n: any) => n.name === "Broadcast Test Goal")).toBe(true);
+
+    ws.close();
+  }, 15000);
 });
 
 describe.serial("Visualization Server - Changesets", () => {

--- a/cli/tests/integration/visualize-node-runtime.test.ts
+++ b/cli/tests/integration/visualize-node-runtime.test.ts
@@ -1,0 +1,159 @@
+/**
+ * End-to-end regression test for #800: `dr visualize` must work on a machine with
+ * only Node.js installed, no Bun.
+ *
+ * PR #803 removed every Bun-specific runtime API (Bun.serve, hono/bun, Bun.spawn/
+ * Bun.spawnSync, Bun.watch) from the visualization server, and changed the CLI to
+ * spawn the server subprocess via `process.execPath` (whichever runtime is already
+ * running the CLI) instead of a literal "bun" binary. Every other visualization-server
+ * integration test in this repo spawns `dr visualize` via `bun ...` (see
+ * visualization-server-api.test.ts, visualization-server-auth-flow.test.ts), so none
+ * of them actually exercise the Node-only code path this fix exists for - the outer
+ * CLI process is always Bun, and so is `process.execPath` inside it.
+ *
+ * This test spawns the CLI via a literal `node` binary AND strips any directory
+ * containing a `bun` executable from the child's PATH, so there is no way for `bun`
+ * to be reached anywhere in the process tree (CLI -> server subprocess -> ...).
+ *
+ * REQUIRES SERIAL EXECUTION: starts a real server subprocess on a live port.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { spawn, spawnSync } from "child_process";
+import { existsSync } from "fs";
+import { mkdir, rm } from "fs/promises";
+import { delimiter, join } from "path";
+import { portAllocator } from "../helpers.ts";
+
+const CLI_ROOT = join(import.meta.dir, "../..");
+const CLI_PATH = join(CLI_ROOT, "dist/cli.js");
+const STARTUP_TIMEOUT = 20000; // ms – generous for CI
+
+/**
+ * Build a PATH string with every directory that contains a `bun` executable removed,
+ * so a child process spawned with this PATH cannot resolve `bun` no matter where it's
+ * installed (asdf/nvm-style user installs, Homebrew, a global CI package, etc.).
+ */
+function pathWithoutBun(): string {
+  const bunExecutableName = process.platform === "win32" ? "bun.exe" : "bun";
+  const dirs = (process.env.PATH || "").split(delimiter);
+  return dirs.filter((dir) => !dir || !existsSync(join(dir, bunExecutableName))).join(delimiter);
+}
+
+function initializeTestModel(dir: string): void {
+  const result = spawnSync("node", [CLI_PATH, "init", "--name", "Node Runtime Test", "--description", "Pure-Node dr visualize e2e test"], {
+    cwd: dir,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(`Failed to init test model: ${result.stderr?.toString()}`);
+  }
+}
+
+async function waitForHealth(port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://localhost:${port}/health`);
+      if (res.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  }
+  throw new Error(`Server at port ${port} did not become healthy within ${timeoutMs}ms`);
+}
+
+describe.serial("dr visualize under a literal pure-Node runtime with Bun entirely unreachable", () => {
+  let testDir: string;
+  let port: number;
+  let serverProc: ReturnType<typeof spawn> | null = null;
+  let serverOutput = "";
+
+  beforeAll(async () => {
+    testDir = join("/tmp", `dr-node-runtime-e2e-${Date.now()}`);
+    await mkdir(testDir, { recursive: true });
+    initializeTestModel(testDir);
+
+    port = await portAllocator.allocatePort();
+
+    const noBunPath = pathWithoutBun();
+    // Sanity-check the filter actually removed something in dev environments where
+    // bun is normally present, so this test can't silently pass by accident on a
+    // machine where `bun` was never on PATH to begin with. On a genuinely bun-less
+    // CI runner this is a no-op, which is fine - the test's real assertion is that
+    // the server works at all, regardless of whether bun was ever present.
+    if (process.env.PATH?.split(delimiter).some((d) => existsSync(join(d, "bun")))) {
+      expect(noBunPath).not.toBe(process.env.PATH);
+    }
+
+    // Spawn the CLI itself via a literal "node" binary (not Bun.spawn/"bun", unlike
+    // every other visualization-server integration test) with Bun stripped from PATH,
+    // so process.execPath inside visualize.ts - and therefore the server subprocess
+    // it spawns - can only ever resolve to node.
+    serverProc = spawn(
+      "node",
+      [CLI_PATH, "visualize", "--port", String(port), "--no-browser", "--no-auth"],
+      {
+        cwd: testDir,
+        env: { ...process.env, PATH: noBunPath },
+        stdio: ["ignore", "pipe", "pipe"],
+      }
+    );
+    serverProc.stdout?.on("data", (d) => (serverOutput += d.toString()));
+    serverProc.stderr?.on("data", (d) => (serverOutput += d.toString()));
+
+    try {
+      await waitForHealth(port, STARTUP_TIMEOUT);
+    } catch (err) {
+      throw new Error(`${(err as Error).message}\nServer output:\n${serverOutput}`);
+    }
+  }, STARTUP_TIMEOUT + 5000);
+
+  afterAll(async () => {
+    if (serverProc && !serverProc.killed) {
+      serverProc.kill();
+    }
+    portAllocator.releasePort(port);
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("serves /health over HTTP with Bun completely unreachable", async () => {
+    const res = await fetch(`http://localhost:${port}/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.status).toBe("ok");
+  });
+
+  it("serves the viewer at / with Bun completely unreachable", async () => {
+    const res = await fetch(`http://localhost:${port}/`);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("<!DOCTYPE html>");
+  });
+
+  it("supports a WebSocket round-trip (ping/pong) with Bun completely unreachable", async () => {
+    await new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(`ws://localhost:${port}/ws`);
+      const timer = setTimeout(() => {
+        ws.close();
+        reject(new Error("WebSocket ping/pong round-trip timed out"));
+      }, 10000);
+
+      ws.onmessage = (event) => {
+        const message = JSON.parse(event.data as string);
+        if (message.type === "connected") {
+          ws.send(JSON.stringify({ type: "ping" }));
+        } else if (message.type === "pong") {
+          clearTimeout(timer);
+          ws.close();
+          resolve();
+        }
+      };
+      ws.onerror = (err) => {
+        clearTimeout(timer);
+        reject(err);
+      };
+    });
+  }, 15000);
+});

--- a/cli/tests/unit/server/chat-subprocess-lifecycle.test.ts
+++ b/cli/tests/unit/server/chat-subprocess-lifecycle.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Regression tests for chat subprocess spawn/kill lifecycle handling in VisualizationServer.
+ *
+ * Covers three bugs fixed during review of PR #803 (Bun -> Node runtime API migration):
+ *
+ * 1. launchClaudeCodeChat/launchCopilotChat previously had no `proc.on("error", ...)`
+ *    listener on the spawned child_process. Node reports spawn failures (ENOENT, EACCES,
+ *    a missing cwd, etc.) asynchronously via an 'error' event rather than a synchronous
+ *    throw - an unhandled 'error' event on an EventEmitter throws, which (via
+ *    server-entry.ts's uncaughtException handler) used to crash the *entire* visualization
+ *    server instead of just failing the one chat request.
+ * 2. killProcessWithRetry used to check `proc.killed` to decide whether a process had
+ *    actually terminated after SIGTERM. Under Node, `.killed` means "kill() was called
+ *    successfully" - NOT "the process has exited" (this differs from Bun's
+ *    Subprocess.killed, which this code was originally written against) - so the SIGKILL
+ *    escalation path silently never ran.
+ *
+ * These tests reach the relevant private methods directly via bracket-notation property
+ * access (`server["methodName"]`), matching the existing convention in
+ * visualization-server.test.ts (see `server["model"]`, `server["clients"]`, etc.).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { spawn, type ChildProcess } from "child_process";
+import { Model } from "../../../src/core/model.js";
+import { VisualizationServer } from "../../../src/server/server.js";
+import { tmpdir } from "os";
+import { join } from "path";
+import { mkdirSync, rmSync } from "fs";
+import { randomUUID } from "crypto";
+
+/** Minimal stand-in for HonoWSContext that just records what would've been sent. */
+function createFakeWs() {
+  const sent: any[] = [];
+  return {
+    sent,
+    send: (data: string) => {
+      sent.push(JSON.parse(data));
+    },
+    close: () => {},
+  };
+}
+
+/** Poll until `check()` returns a truthy value, or fail after `timeoutMs`. */
+async function waitFor<T>(check: () => T | undefined | null | false, timeoutMs = 5000): Promise<T> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const result = check();
+    if (result) return result;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`);
+}
+
+describe("VisualizationServer chat subprocess spawn error handling", () => {
+  let testDir: string;
+  let model: Model;
+  let server: VisualizationServer;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `dr-spawn-err-${randomUUID()}`);
+    mkdirSync(testDir, { recursive: true });
+    model = await Model.init(
+      testDir,
+      {
+        name: "Spawn Error Test",
+        version: "0.1.0",
+        description: "Model for chat subprocess spawn-error regression tests",
+        specVersion: "0.6.0",
+        created: new Date().toISOString(),
+      },
+      { lazyLoad: false }
+    );
+    server = new VisualizationServer(model, { authEnabled: false });
+
+    // Force any child_process.spawn launched with `cwd: this.model.rootPath` (which is
+    // what launchClaudeCodeChat/launchCopilotChat use) to fail deterministically with
+    // ENOENT, without touching global state like process.env.PATH - which would be
+    // unsafe here since tests/unit/server/ runs with --concurrent and a global PATH
+    // mutation could affect other files' subprocess spawns running at the same time.
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    server.stop();
+  });
+
+  it("launchClaudeCodeChat: a spawn failure sends a JSON-RPC error instead of crashing the process", async () => {
+    const ws = createFakeWs();
+
+    // If the fix regresses (no proc.on("error", ...) listener), this either hangs the
+    // test (unhandled 'error' events don't reject this await) or - in a real server -
+    // throws an uncaught exception process-wide, which is exactly the bug being guarded
+    // against. Either way, `await` on the launch call itself succeeds regardless, since
+    // the spawn error surfaces asynchronously after the method returns.
+    await (server as any).launchClaudeCodeChat(ws, "conv-claude-spawn-err", "hello", "req-claude-1");
+
+    const response = await waitFor(() => ws.sent.find((m) => m.id === "req-claude-1"));
+    expect(response.jsonrpc).toBe("2.0");
+    expect(response.error).toBeDefined();
+    expect(response.error.message).toContain("Failed to launch Claude Code");
+
+    // Cleanup on failure must still happen
+    expect((server as any).activeChatProcesses.has("conv-claude-spawn-err")).toBe(false);
+
+    // A failed spawn also destroys proc.stdout, which the stream-reading loop observes
+    // as its own error - guard against that turning into a second, duplicate JSON-RPC
+    // response for the same request id.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(ws.sent.filter((m) => m.id === "req-claude-1")).toHaveLength(1);
+  });
+
+  it("launchCopilotChat: a spawn failure sends a JSON-RPC error instead of crashing the process", async () => {
+    const ws = createFakeWs();
+
+    await (server as any).launchCopilotChat(ws, "conv-copilot-spawn-err", "hello", "req-copilot-1");
+
+    const response = await waitFor(() => ws.sent.find((m) => m.id === "req-copilot-1"));
+    expect(response.jsonrpc).toBe("2.0");
+    expect(response.error).toBeDefined();
+    expect(response.error.message).toMatch(/Failed to launch GitHub Copilot/);
+
+    expect((server as any).activeChatProcesses.has("conv-copilot-spawn-err")).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(ws.sent.filter((m) => m.id === "req-copilot-1")).toHaveLength(1);
+  });
+});
+
+describe("VisualizationServer process exit/kill helpers", () => {
+  let testDir: string;
+  let model: Model;
+  let server: VisualizationServer;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `dr-kill-retry-${randomUUID()}`);
+    mkdirSync(testDir, { recursive: true });
+    model = await Model.init(
+      testDir,
+      {
+        name: "Kill Retry Test",
+        version: "0.1.0",
+        description: "Model for killProcessWithRetry/waitForExit regression tests",
+        specVersion: "0.6.0",
+        created: new Date().toISOString(),
+      },
+      { lazyLoad: false }
+    );
+    server = new VisualizationServer(model, { authEnabled: false });
+  });
+
+  afterAll(() => {
+    server.stop();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("waitForExit resolves with the actual exit code once the process exits", async () => {
+    const proc: ChildProcess = spawn(process.execPath, ["-e", "process.exit(3)"]);
+    const code = await (server as any).waitForExit(proc);
+    expect(code).toBe(3);
+  });
+
+  it("waitForExit resolves immediately for a process that already exited before being awaited", async () => {
+    const proc: ChildProcess = spawn(process.execPath, ["-e", "process.exit(0)"]);
+    await new Promise((resolve) => proc.once("exit", resolve));
+    expect(proc.exitCode).not.toBeNull();
+
+    const code = await (server as any).waitForExit(proc);
+    expect(code).toBe(0);
+  });
+
+  it(
+    "killProcessWithRetry escalates to SIGKILL when SIGTERM never actually terminates the process",
+    async () => {
+      // A real OS-level SIGTERM-ignoring process (e.g. `sh -c "trap '' TERM; ..."`) is
+      // the most realistic way to exercise this, but that trap turned out to be
+      // unreliable specifically under `bun test`'s own process supervision (confirmed:
+      // the identical spawn+kill sequence reliably ignores SIGTERM under plain
+      // `bun -e`/`node -e`, but not under `bun test`) - a test-runner quirk unrelated to
+      // the actual bug. So instead, fake a minimal ChildProcess that precisely models
+      // the real contract killProcessWithRetry depends on: `.killed` becomes true as
+      // soon as kill() is *called* (matching real Node semantics), but `exitCode`/
+      // `signalCode` - what hasExited() actually checks - stay null until a real
+      // termination signal (SIGKILL, which can't be trapped) is sent. This is exactly
+      // the distinction the fix (`hasExited()` checking exitCode/signalCode instead of
+      // `.killed`) exists to get right.
+      const killCalls: string[] = [];
+      let exitCode: number | null = null;
+      let signalCode: string | null = null;
+      const fakeProc = {
+        get exitCode() {
+          return exitCode;
+        },
+        get signalCode() {
+          return signalCode;
+        },
+        get killed() {
+          return killCalls.length > 0;
+        },
+        kill(signal: string) {
+          killCalls.push(signal);
+          if (signal === "SIGKILL") {
+            signalCode = "SIGKILL";
+          }
+          // SIGTERM is deliberately not honored - simulates a process that ignores it.
+          return true;
+        },
+      };
+
+      await (server as any).killProcessWithRetry(fakeProc, "conv-kill-retry", "TestLabel");
+
+      expect(killCalls).toContain("SIGTERM");
+      expect(killCalls[killCalls.length - 1]).toBe("SIGKILL");
+      expect(fakeProc.signalCode).toBe("SIGKILL");
+    },
+    10000
+  );
+
+  it("killProcessWithRetry returns immediately for an already-exited process", async () => {
+    const proc: ChildProcess = spawn(process.execPath, ["-e", "process.exit(0)"]);
+    await new Promise((resolve) => proc.once("exit", resolve));
+
+    const start = Date.now();
+    await (server as any).killProcessWithRetry(proc, "conv-already-exited", "TestLabel");
+    // Should return near-instantly (no SIGTERM wait/backoff), not take the ~1.8s of a
+    // full retry cycle.
+    expect(Date.now() - start).toBeLessThan(200);
+  });
+});

--- a/cli/tests/unit/server/http-bind-error.test.ts
+++ b/cli/tests/unit/server/http-bind-error.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression test for VisualizationServer.start()'s HTTP bind-error handling.
+ *
+ * Before the Bun -> Node runtime migration (PR #803), a bind failure surfaced
+ * synchronously: Bun.serve() threw directly, which start() propagated out to
+ * server-entry.ts's main() try/catch for a clean, actionable error message.
+ *
+ * @hono/node-server's serve() wraps Node's http.Server, which reports bind
+ * failures (most realistically EADDRINUSE, e.g. from a still-running previous
+ * `dr visualize` instance) asynchronously via an 'error' event instead. Without
+ * waiting on that event, the failure would instead surface as an unhandled
+ * 'error' event -> uncaughtException -> a full process crash with a generic
+ * Node stack dump, rather than a clean rejection through the existing startup
+ * error path.
+ */
+
+import { describe, it, expect, afterAll } from "bun:test";
+import { Model } from "../../../src/core/model.js";
+import { VisualizationServer } from "../../../src/server/server.js";
+import { portAllocator } from "../../helpers/port-allocator.js";
+import { tmpdir } from "os";
+import { join } from "path";
+import { mkdirSync, rmSync } from "fs";
+import { randomUUID } from "crypto";
+
+async function makeServer(label: string): Promise<{ server: VisualizationServer; testDir: string }> {
+  const testDir = join(tmpdir(), `dr-bind-err-${label}-${randomUUID()}`);
+  mkdirSync(testDir, { recursive: true });
+  const model = await Model.init(
+    testDir,
+    {
+      name: `Bind Error Test (${label})`,
+      version: "0.1.0",
+      description: "Model for start() EADDRINUSE regression test",
+      specVersion: "0.6.0",
+      created: new Date().toISOString(),
+    },
+    { lazyLoad: false }
+  );
+  return { server: new VisualizationServer(model, { authEnabled: false }), testDir };
+}
+
+describe("VisualizationServer.start() bind error handling", () => {
+  const cleanup: Array<() => void> = [];
+
+  afterAll(() => {
+    for (const fn of cleanup) fn();
+  });
+
+  it("rejects cleanly with an actionable message when the port is already in use", async () => {
+    const port = await portAllocator.allocatePort();
+
+    const { server: server1, testDir: dir1 } = await makeServer("first");
+    await server1.start(port);
+    cleanup.push(() => {
+      server1.stop();
+      rmSync(dir1, { recursive: true, force: true });
+    });
+
+    const { server: server2, testDir: dir2 } = await makeServer("second");
+    cleanup.push(() => rmSync(dir2, { recursive: true, force: true }));
+
+    let caught: Error | undefined;
+    try {
+      await server2.start(port);
+      // If we get here, start() didn't reject - fail explicitly rather than via a
+      // missing assertion, and make sure we don't leak a second bound server.
+      server2.stop();
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught?.message).toMatch(/already in use/i);
+    expect(caught?.message).toContain(String(port));
+
+    // The first server must still be alive and unaffected by the second's failed start.
+    const res = await fetch(`http://localhost:${port}/health`);
+    expect(res.status).toBe(200);
+
+    portAllocator.releasePort(port);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #800. `dr visualize`'s server had a hard runtime dependency on Bun-specific APIs (`Bun.serve()`, `hono/bun`, `Bun.spawn`/`Bun.spawnSync`, `Bun.watch`), so it crashed (or previously just showed an actionable error, per #799) on any machine without a separate Bun install. This removes that dependency entirely.

## Changes

| Bun API | Replacement |
|---|---|
| `Bun.serve()` | `@hono/node-server`'s `serve()` |
| `hono/bun` (`upgradeWebSocket`/`websocket`) | `@hono/node-ws`'s `createNodeWebSocket()`, set up per server instance and wired via `injectWebSocket()` in `start()` |
| `Bun.spawn` / `Bun.spawnSync` (chat subprocess launch) | `child_process.spawn` / `spawnSync`; the Web-Streams `.getReader()` loop became `for await (const chunk of proc.stdout)`; added a `waitForExit()` helper to replace the Bun-only `proc.exited` promise |
| `Bun.watch` | `chokidar` (cross-platform recursive watching — Node's `fs.watch({recursive})` doesn't support Linux) |

`cli/src/commands/visualize.ts` now spawns `server-entry.js` via `process.execPath` instead of a literal `"bun"` binary — it reuses whichever interpreter (Node or Bun) is already running the CLI, so it can no longer `ENOENT` on a fresh `npm install -g` with no Bun present. Simplified the now-moot Bun-specific error messaging in the subprocess `error` handler accordingly.

New production dependencies: `@hono/node-server@^1.19.17`, `@hono/node-ws@^1.3.1`, `chokidar@^4.0.3`. (Pinned `@hono/node-server` to the 1.x line since `@hono/node-ws`'s peer dependency requires `^1.19.11`, not the 2.x line.)

Kept the subprocess architecture (`visualize.ts` spawning `server-entry.js`) rather than the fuller "instantiate `VisualizationServer` directly" rewrite the issue mentions as optional (`could`) — that would touch signal handling, telemetry spans, and TOKEN-line stdout scraping for no gain toward the acceptance criteria.

## Testing

- `tsc --noEmit` / `npm run build`: clean
- `npm run test:unit`: 1,574 pass
- `tests/unit/server/`: 158 pass
- `tests/integration/visualization-server-comprehensive.test.ts`: 38 pass, including real WebSocket connect/ping-pong against the new `@hono/node-ws` stack
- `tests/integration/visualization-server-auth-flow.test.ts`: 12 pass — spawns the real `dr visualize` subprocess end-to-end via the new `process.execPath` path
- `tests/integration/visualization-server-relationship-links.test.ts`: 6 pass
- **Manual smoke test**: stripped `bun` entirely from `PATH`, ran `node dist/cli.js visualize` against a fresh model — server started, `/health` returned 200, and a WebSocket ping/pong round-tripped successfully, all under pure Node with zero Bun involvement
- Full `tests/integration/*.test.ts` sweep (63 files) and `visualization-server-api.test.ts` both have pre-existing failures unrelated to this change (confirmed identical failures on `main` before this diff, via stash-and-rerun) — not introduced by this PR

## Acceptance criteria (from #800)

- [x] `dr visualize` works end-to-end (server starts, WebSocket chat works, file watching works) on a machine with only Node installed, no Bun
- [x] Existing Bun-based dev/CI workflows (`npm run build`, `bun test`, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)