### PR TITLE
chore(release): bump CLI to v0.1.13

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 1. **CLI Tool (`cli/`)** - TypeScript implementation for managing architecture models
 2. **Metadata Model Specification** - Formal documentation defining the 13-layer model
 
-**Current Versions:** CLI v0.1.12, Spec v0.9.0
+**Current Versions:** CLI v0.1.13, Spec v0.9.0
 
 ## Repository Structure
 
@@ -193,8 +193,7 @@ Federated architecture model spanning 13 interconnected layers:
   - Layers: `documentation-robotics/model/{layer-number}_{layer-name}/`
 - **Changesets** in `documentation-robotics/changesets/` directory
   - Each changeset: `{changeset-id}/metadata.yaml` and `changes.yaml`
-  - Migration: Old `.dr/changesets/` auto-migrates to new location on first use
-  - Backup: `.dr.backup/changesets/` created during migration for rollback
+- **Spec-version model migrations** (e.g. layer renumbering) are handled by `dr upgrade`, driven by `cli/src/core/migration-registry.ts` — see `MigrationRegistry` for the version-to-version migration path and `cli/src/commands/upgrade.ts` for the CLI flow
 
 ## Common Pitfalls
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13] - 2026-08-21
+
+**Specification Support:** v0.9.0 (now formally tagged as `spec-v0.9.0`; CLI content support is unchanged from 0.1.12)
+
+### Changed
+
+- **Bundled viewer bumped to v0.6.1**: `documentation_robotics_viewer` moves `0.6.0` → `0.6.1`,
+  picking up native `heimdall-ui` 0.8.0 edge-hover support and model-graph/node-page fixes. No
+  CLI-side API changes required — the viewer continues to consume the existing `/api/model` and
+  `/api/spec` shapes.
+
+### Testing
+
+- **Added end-to-end coverage for the pre-0.8.2 legacy slug-id migration** in
+  `Model.load()`/`loadLayer()` (`tests/integration/model-legacy-migration.test.ts`). Previously
+  this migration — which rewrites a legacy `id: {layer}.{type}.{slug}` element to a deterministic
+  UUID `id` plus a `path` carrying the old slug, transparently on every load — only had thin,
+  indirect unit coverage (`model-deterministic-uuid.test.ts`) that never actually loaded a
+  legacy-format YAML file through the real `Model.load()` API. The new tests write real pre-0.8.2
+  YAML to disk and verify: the migration fires and produces a stable, deterministic UUID across
+  repeated loads; an already-migrated (UUID id + path) element passes through unchanged; and the
+  migration works for layers beyond `motivation` (verified against `product`, added in spec
+  v0.9.0).
+
+### Documentation
+
+- Corrected `CLAUDE.md` and `README.md`, which both described a `.dr/changesets` →
+  `documentation-robotics/changesets` auto-migration (with `.dr.backup/` rollback) that no longer
+  exists in source — it was removed in an earlier fix and the docs were never updated. Both now
+  point at the actual mechanism for spec-version model migrations: `dr upgrade`, driven by
+  `MigrationRegistry` (`cli/src/core/migration-registry.ts`).
+- Fixed a dangling "see migration guide" reference in `spec/CHANGELOG.md`'s 0.9.0 entry — no such
+  guide exists; the reference now points at `dr upgrade`, which already automates the 13-layer
+  renumbering migration (and has been covered by `migration-registry.test.ts` and
+  `upgrade-command.test.ts` since it shipped).
+
 ## [0.1.12] - 2026-08-19
 
 **Specification Support:** v0.9.0

--- a/cli/README.md
+++ b/cli/README.md
@@ -289,7 +289,7 @@ your-project/
 │       └── ...
 ```
 
-**Legacy models**: Old projects using `.dr/` directory will auto-migrate changesets to `documentation-robotics/changesets/` on first use.
+**Spec-version migrations**: When the model's spec version is older than the CLI's bundled spec (e.g. after a layer renumbering), run `dr upgrade` to migrate the on-disk model in place — see `MigrationRegistry` in `cli/src/core/migration-registry.ts` for the supported version paths.
 
 ### Specification Reference
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@documentation-robotics/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@documentation-robotics/cli",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@documentation-robotics/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "CLI for Documentation Robotics",
   "type": "module",
   "main": "dist/cli.js",

--- a/cli/scripts/download-viewer.sh
+++ b/cli/scripts/download-viewer.sh
@@ -3,7 +3,7 @@
 # Skips the download if the correct version is already present.
 set -euo pipefail
 
-VIEWER_VERSION="0.6.0"
+VIEWER_VERSION="0.6.1"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 VIEWER_DIR="$SCRIPT_DIR/../src/viewer"
 VERSION_FILE="$VIEWER_DIR/version.json"

--- a/cli/tests/integration/model-legacy-migration.test.ts
+++ b/cli/tests/integration/model-legacy-migration.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Integration tests for the legacy slug-id → UUID+path migration performed by
+ * `Model.loadLayer()` (see cli/src/core/model.ts, the "3-case migration logic").
+ *
+ * Prior to spec v0.8.2, an element's `id` field held the human-readable slug
+ * (e.g. `motivation.goal.customer-satisfaction`) directly and there was no
+ * separate `path` field. Since 0.8.2, `id` is a UUIDv4 and `path` carries the
+ * slug. `Model.loadLayer()` migrates the old shape to the new one transparently
+ * on every load — it is not a one-time versioned migration step, so there is no
+ * `dr upgrade` path for it; any project with pre-0.8.2 YAML on disk is migrated
+ * in memory the moment it's loaded.
+ *
+ * Existing coverage (model-deterministic-uuid.test.ts) only exercises the
+ * Layer/Element storage contract the migration relies on, with pre-computed
+ * UUID/path pairs — it never loads a real legacy-format YAML file through
+ * `Model.load()`. These tests close that gap by writing actual pre-0.8.2 YAML
+ * to disk and loading it through the real public API.
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import yaml from "yaml";
+import { Model } from "../../src/core/model.js";
+
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** Writes a minimal but realistic manifest.yaml + one layer directory to a fresh temp project root. */
+async function writeLegacyProject(
+  root: string,
+  layerDirName: string,
+  fileName: string,
+  elements: Record<string, unknown>
+): Promise<void> {
+  const modelDir = join(root, "documentation-robotics", "model");
+  const layerDir = join(modelDir, layerDirName);
+  await mkdir(layerDir, { recursive: true });
+
+  const manifest = {
+    schema: "documentation-robotics-v1",
+    cli_version: "0.7.0",
+    spec_version: "0.8.1",
+    created: "2025-01-01T00:00:00Z",
+    updated: "2025-01-01T00:00:00Z",
+    project: { name: "Legacy Test Project", description: "", version: "1.0.0" }
+  };
+  await writeFile(join(modelDir, "manifest.yaml"), yaml.stringify(manifest));
+  await writeFile(join(layerDir, fileName), yaml.stringify(elements));
+}
+
+describe("Legacy slug-id migration (Model.load → loadLayer)", () => {
+  let workdir: string | undefined;
+
+  afterEach(async () => {
+    if (workdir) {
+      await rm(workdir, { recursive: true, force: true });
+      workdir = undefined;
+    }
+  });
+
+  it("migrates a pre-0.8.2 slug id to a deterministic UUID id + slug path", async () => {
+    workdir = await mkdtemp(join(tmpdir(), "dr-legacy-migration-"));
+
+    // Pre-0.8.2 shape: `id` is the slug itself, no `path` field at all.
+    await writeLegacyProject(workdir, "01_motivation", "goal.yaml", {
+      "motivation.goal.customer-satisfaction": {
+        id: "motivation.goal.customer-satisfaction",
+        type: "goal",
+        layer_id: "motivation",
+        name: "Customer Satisfaction",
+        description: "Increase customer satisfaction score"
+      }
+    });
+
+    const model = await Model.load(workdir);
+    const layer = await model.getLayer("motivation");
+    expect(layer).toBeDefined();
+
+    const element = layer!.getElement("motivation.goal.customer-satisfaction");
+    expect(element).toBeDefined();
+    expect(element!.path).toBe("motivation.goal.customer-satisfaction");
+    expect(element!.id).toMatch(UUID_V4_REGEX);
+    // The old slug must not survive as the `id` after migration.
+    expect(element!.id).not.toBe("motivation.goal.customer-satisfaction");
+  });
+
+  it("derives the same UUID on repeated loads of the same legacy element (deterministic)", async () => {
+    workdir = await mkdtemp(join(tmpdir(), "dr-legacy-migration-det-"));
+
+    await writeLegacyProject(workdir, "01_motivation", "goal.yaml", {
+      "motivation.goal.stable-goal": {
+        id: "motivation.goal.stable-goal",
+        type: "goal",
+        layer_id: "motivation",
+        name: "Stable Goal"
+      }
+    });
+
+    const firstLoad = await Model.load(workdir);
+    const firstElement = (await firstLoad.getLayer("motivation"))!.getElement(
+      "motivation.goal.stable-goal"
+    );
+
+    const secondLoad = await Model.load(workdir);
+    const secondElement = (await secondLoad.getLayer("motivation"))!.getElement(
+      "motivation.goal.stable-goal"
+    );
+
+    expect(firstElement!.id).toMatch(UUID_V4_REGEX);
+    expect(firstElement!.id).toBe(secondElement!.id);
+    expect(firstElement!.path).toBe(secondElement!.path);
+  });
+
+  it("leaves an already-migrated (UUID id + path) element unchanged", async () => {
+    workdir = await mkdtemp(join(tmpdir(), "dr-legacy-migration-modern-"));
+
+    const existingUuid = "550e8400-e29b-41d4-a716-446655440000";
+    await writeLegacyProject(workdir, "01_motivation", "goal.yaml", {
+      "motivation.goal.already-modern": {
+        id: existingUuid,
+        path: "motivation.goal.already-modern",
+        spec_node_id: "motivation.goal",
+        type: "goal",
+        layer_id: "motivation",
+        name: "Already Modern"
+      }
+    });
+
+    const model = await Model.load(workdir);
+    const element = (await model.getLayer("motivation"))!.getElement(
+      "motivation.goal.already-modern"
+    );
+
+    // Case 1 (already has both a UUID id and a path) must pass through untouched.
+    expect(element!.id).toBe(existingUuid);
+    expect(element!.path).toBe("motivation.goal.already-modern");
+  });
+
+  it("migrates a legacy element in a non-motivation layer (product, added in spec v0.9.0)", async () => {
+    workdir = await mkdtemp(join(tmpdir(), "dr-legacy-migration-product-"));
+
+    await writeLegacyProject(workdir, "03_product", "persona.yaml", {
+      "product.persona.power-user": {
+        id: "product.persona.power-user",
+        type: "persona",
+        layer_id: "product",
+        name: "Power User"
+      }
+    });
+
+    const model = await Model.load(workdir);
+    const element = (await model.getLayer("product"))!.getElement(
+      "product.persona.power-user"
+    );
+
+    expect(element).toBeDefined();
+    expect(element!.path).toBe("product.persona.power-user");
+    expect(element!.id).toMatch(UUID_V4_REGEX);
+  });
+});

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -7,36 +7,7 @@ and this specification adheres to [Semantic Versioning](https://semver.org/spec/
 
 ## [Unreleased]
 
-### Added
-
-- **Analyzer Mappings Framework** — Introduced `spec/analyzers/` as the canonical home for analyzer
-  mappings that bridge external code analysis tools to the architecture model:
-  - New directory structure at `spec/analyzers/{analyzer-name}/` containing analyzer definitions
-  - Four new base schemas for analyzer compilation: `analyzer-spec.schema.json`,
-    `analyzer-node-mapping.schema.json`, `analyzer-edge-mapping.schema.json`, and
-    `analyzer-heuristics.schema.json` — all validated during spec build
-- **Codebase Memory (CBM) Analyzer Mapping** — First analyzer mapping (`cbm`) covering semantic
-  code structures from the Codebase Memory MCP:
-  - Node label mappings: **Route** → `api.operation`, **Function** → `application.applicationfunction`,
-    **Method** → `application.applicationfunction`, **Class** → `application.applicationcomponent`,
-    **Module** → `application.applicationcomponent`
-  - Edge type mappings: HTTP calls → `consumes`, request handlers → `provides`, with unmappable
-    edges (function calls, imports, inheritance) marked with `null` dr_relationship
-  - Extraction heuristics for guiding semantic graph generation from source code
-- **Build Pipeline Enhancements** — Extended `spec/scripts/build-spec.ts` with analyzer
-  compilation and validation that compiles all analyzer directories into `spec/dist/analyzers/`:
-  - Validates required files exist: `analyzer.json`, `node-mapping.json`, `edge-mapping.json`,
-    `extraction-heuristics.json`
-  - Validates all `dr_layer` values use canonical layer names and `dr_relationship` values exist in `predicates.json` (null allowed for unmappable edges)
-  - Generates packed analyzer artifacts with indexed node mappings and edge types
-  - Creates `spec/dist/analyzers/manifest.json` listing all compiled analyzers with versions
-
-### Changed
-
-- **Spec Build Output** now includes `spec/dist/analyzers/` subtree alongside layer and base schema
-  files, expanding the compiled specification to cover analyzer-to-model mappings
-
-## [0.9.0] - 2026-08-13
+## [0.9.0] - 2026-08-21
 
 ### Breaking Changes
 
@@ -52,7 +23,7 @@ and this specification adheres to [Semantic Versioning](https://semver.org/spec/
     - Navigation: 10 → 11
     - APM: 11 → 12
     - Testing: 12 → 13
-  - **Impact**: Layer filesystem prefixes and archive paths update (e.g., `03_security/` → `04_security/`). Cross-layer references remain stable (use layer names not numbers). Filesystem-based models require directory renames during migration; see migration guide.
+  - **Impact**: Layer filesystem prefixes and archive paths update (e.g., `03_security/` → `04_security/`). Cross-layer references remain stable (use layer names not numbers). Filesystem-based models are migrated automatically by running `dr upgrade` (CLI v0.1.8+), which renames the affected layer directories and updates `manifest.yaml` in place — no manual steps required.
 
 ### Added
 
@@ -73,10 +44,33 @@ and this specification adheres to [Semantic Versioning](https://semver.org/spec/
   - Updated all shifted layer prefixes (04-security through 13-testing)
   - Added `product` to `NODE_FOLDER_TO_LAYER` mapping and `dr_layer` TypeScript union type
 - **Spec Distribution** — Compiled `spec/dist/` now includes `product.json` (product layer node/relationship schemas) alongside updated manifest and renumbered layer files (14 → 15 total files)
+- **Analyzer Mappings Framework** — Introduced `spec/analyzers/` as the canonical home for analyzer
+  mappings that bridge external code analysis tools to the architecture model:
+  - New directory structure at `spec/analyzers/{analyzer-name}/` containing analyzer definitions
+  - Four new base schemas for analyzer compilation: `analyzer-spec.schema.json`,
+    `analyzer-node-mapping.schema.json`, `analyzer-edge-mapping.schema.json`, and
+    `analyzer-heuristics.schema.json` — all validated during spec build
+- **Codebase Memory (CBM) Analyzer Mapping** — First analyzer mapping (`cbm`) covering semantic
+  code structures from the Codebase Memory MCP:
+  - Node label mappings: **Route** → `api.operation`, **Function** → `application.applicationfunction`,
+    **Method** → `application.applicationfunction`, **Class** → `application.applicationcomponent`,
+    **Module** → `application.applicationcomponent`
+  - Edge type mappings: HTTP calls → `consumes`, request handlers → `provides`, with unmappable
+    edges (function calls, imports, inheritance) marked with `null` dr_relationship
+  - Extraction heuristics for guiding semantic graph generation from source code
+- **Analyzer Build Pipeline** — Extended `spec/scripts/build-spec.ts` with analyzer
+  compilation and validation that compiles all analyzer directories into `spec/dist/analyzers/`:
+  - Validates required files exist: `analyzer.json`, `node-mapping.json`, `edge-mapping.json`,
+    `extraction-heuristics.json`
+  - Validates all `dr_layer` values use canonical layer names and `dr_relationship` values exist in `predicates.json` (null allowed for unmappable edges)
+  - Generates packed analyzer artifacts with indexed node mappings and edge types
+  - Creates `spec/dist/analyzers/manifest.json` listing all compiled analyzers with versions
 
 ### Changed
 
 - **Layer Numbering Schema** — All 12 existing layers renumbered to accommodate Product layer insertion (affects layer instance files, archive paths, layer-specific documentation, but not cross-layer references which use layer names)
+- **Spec Build Output** now includes `spec/dist/analyzers/` subtree alongside layer and base schema
+  files, expanding the compiled specification to cover analyzer-to-model mappings
 
 ### Compatibility
 


### PR DESCRIPTION
## Summary

- Bump bundled viewer `0.6.0` → `0.6.1` (native heimdall-ui 0.8.0 edge-hover support + model-graph/node-page fixes)
- Add e2e test coverage for pre-0.8.2 legacy slug-id migration in `Model.load()` (`tests/integration/model-legacy-migration.test.ts`)
- Correct stale `.dr/changesets` auto-migration docs in `CLAUDE.md` and `cli/README.md` — now points at `dr upgrade` / `MigrationRegistry`
- Fix dangling "see migration guide" reference in `spec/CHANGELOG.md` 0.9.0 entry

## Changes

| File | Change |
|------|--------|
| `cli/package.json`, `package-lock.json` | `0.1.12` → `0.1.13` |
| `cli/scripts/download-viewer.sh` | viewer `0.6.0` → `0.6.1` |
| `cli/tests/integration/model-legacy-migration.test.ts` | new: e2e slug-id migration test |
| `cli/CHANGELOG.md` | adds `[0.1.13]` entry |
| `spec/CHANGELOG.md` | moves Analyzer Mappings into `[0.9.0]`; fixes migration guide ref |
| `CLAUDE.md`, `cli/README.md` | doc corrections (stale changeset migration text)